### PR TITLE
Improve neovim buffering

### DIFF
--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -52,10 +52,21 @@ function! flutter#_on_exit_nvim(job_id, data, event) abort dict
   endif
 endfunction
 
+let g:flutter_partial_line_nvim = ''
 function! flutter#_on_output_nvim(job_id, data, event) abort dict
   if !empty(a:data)
-    let lines = filter(a:data, '!empty(v:val)')
-    call nvim_buf_set_lines(bufnr('__Flutter_Output__'), -1, -1, v:true, lines)
+    " Append the first element to the previous partial line
+    let g:flutter_partial_line_nvim .= a:data[0]
+    " Check if any newlines to be printed
+    if len(a:data) > 1
+      let b = bufnr('__Flutter_Output__')
+      " Print the now-finished partial line
+      call nvim_buf_set_lines(b, -1, -1, v:true, [g:flutter_partial_line_nvim])
+      " Print the rest of the complete lines (except the last)
+      call nvim_buf_set_lines(b, -1, -1, v:true, a:data[1:-2])
+      " Start the next partial line with the last element
+      let g:nvim_partial_line = a:data[-1]
+    endif
   endif
 endfunction
 endif

--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -45,6 +45,7 @@ function! flutter#_exit_cb(job, status) abort
   call job_stop(a:job)
 endfunction
 
+if has('nvim')
 function! flutter#_on_exit_nvim(job_id, data, event) abort dict
   if exists('g:flutter_job')
     unlet g:flutter_job
@@ -57,6 +58,7 @@ function! flutter#_on_output_nvim(job_id, data, event) abort dict
     call nvim_buf_set_lines(bufnr('__Flutter_Output__'), -1, -1, v:true, lines)
   endif
 endfunction
+endif
 
 function! flutter#run(...) abort
  if exists('g:flutter_job')

--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -49,7 +49,6 @@ function! flutter#_on_exit_nvim(job_id, data, event) abort dict
   if exists('g:flutter_job')
     unlet g:flutter_job
   endif
-  call jobstop(a:job_id)
 endfunction
 
 function! flutter#_on_output_nvim(job_id, data, event) abort dict


### PR DESCRIPTION
A different approach to neovim stdout/stderr callbacks which handles cases where they do not end in newlines. Also removes un-needed `jobstop` from the `on_exit` callback handler.