### PR TITLE
Fix global config leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Ultimately, installation is up to you.
 * `g:flutter_command` - The Flutter executable path/name; defaults to `'flutter'`.
 * `g:flutter_hot_reload_on_save` - Whether to auto hot-reload when `dart` files
 are saved; defaults to `1`.
+* `g:flutter_show_log_on_run` - Automatically open `__Flutter_Output__` when starting
+flutter; defaults to `1`.
 
 ## Provided Commands
 * `:FlutterRun <args>` - calls `flutter run <args>`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ultimately, installation is up to you.
 * `g:flutter_hot_reload_on_save` - Whether to auto hot-reload when `dart` files
 are saved; defaults to `1`.
 * `g:flutter_show_log_on_run` - Automatically open `__Flutter_Output__` when starting
-flutter; defaults to `1`.
+flutter; defaults to `1`. Setting this to 0 requires `set hidden` in your vimrc.
 
 ## Provided Commands
 * `:FlutterRun <args>` - calls `flutter run <args>`

--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -92,20 +92,18 @@ endfunction
 endif
 
 function! flutter#run(...) abort
- if exists('g:flutter_job')
-   echoerr 'Another Flutter process is running.'
-   return 0
- endif
- split __Flutter_Output__
- normal! ggdG
- setlocal buftype=nofile
- setlocal bufhidden=hide
- setlocal showcmd
- setlocal noruler
- setlocal noswapfile
- setlocal hidden
- setlocal noshowmode
- setlocal laststatus=0
+  if exists('g:flutter_job')
+    echoerr 'Another Flutter process is running.'
+    return 0
+  endif
+
+  if g:flutter_show_log_on_run
+    split __Flutter_Output__
+    normal! ggdG
+    setlocal buftype=nofile
+    setlocal bufhidden=hide
+    setlocal noswapfile
+  endif
 
   let cmd = g:flutter_command.' run'
   if !empty(a:000)
@@ -114,18 +112,18 @@ function! flutter#run(...) abort
 
   if has('nvim')
     let g:flutter_job = jobstart(cmd, {
-      \ 'on_stdout' : function('flutter#_on_output_nvim'),
-      \ 'on_stderr' : function('flutter#_on_output_nvim'),
-      \ 'on_exit' : function('flutter#_on_exit_nvim'),
-      \ })
+          \ 'on_stdout' : function('flutter#_on_output_nvim'),
+          \ 'on_stderr' : function('flutter#_on_output_nvim'),
+          \ 'on_exit' : function('flutter#_on_exit_nvim'),
+          \ })
   elseif v:version >= 800
     let g:flutter_job = job_start(cmd, {
-      \ 'out_io': 'buffer',
-      \ 'out_name': '__Flutter_Output__',
-      \ 'err_io': 'buffer',
-      \ 'err_name': '__Flutter_Output__',
-      \ 'exit_cb': 'flutter#_exit_cb',
-      \ })
+          \ 'out_io': 'buffer',
+          \ 'out_name': '__Flutter_Output__',
+          \ 'err_io': 'buffer',
+          \ 'err_name': '__Flutter_Output__',
+          \ 'exit_cb': 'flutter#_exit_cb',
+          \ })
   else
     echoerr 'This vim does not support async jobs needed for running Flutter.'
   endif

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -22,7 +22,7 @@ command! FlutterQuit call flutter#quit()
 command! FlutterVisualDebug call flutter#visual_debug()
 
 if g:flutter_hot_reload_on_save
-  autocmd FileType dart autocmd BufWritePost <buffer> call flutter#hot_reload_quiet()
+  autocmd! BufWritePost *.dart call flutter#hot_reload_quiet()
 endif
 
 command! FlutterSplit :split __Flutter_Output__

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -14,6 +14,9 @@ endif
 
 if !exists('g:flutter_show_log_on_run')
   let g:flutter_show_log_on_run=1
+elseif &hidden == 0 && g:flutter_show_log_on_run == 0
+  echoerr "WARNING: Hidden buffers are disabled. Setting g:flutter_show_log_on_run to 1. Please add `set hidden` to your vimrc to keep the flutter log in the background."
+  let g:flutter_show_log_on_run = 1
 endif
 
 command! FlutterDevices call flutter#devices()

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -12,6 +12,10 @@ if !exists('g:flutter_hot_reload_on_save')
   let g:flutter_hot_reload_on_save=1
 endif
 
+if !exists('g:flutter_show_log_on_run')
+  let g:flutter_show_log_on_run=1
+endif
+
 command! FlutterDevices call flutter#devices()
 command! FlutterEmulators call flutter#emulators()
 command! -nargs=1 FlutterEmulatorsLaunch call flutter#emulators_launch(<f-args>)


### PR DESCRIPTION
This PR adds the option to leave the `__Flutter_Output__` buffer hidden when you first run `:FlutterRun`. The buffer is still created in the background, and is available if you want it. The default behaviour is to open the buffer.

I've also removed some `setlocal`s from the same part of the code, since they were modifying global config in an undesirable way (often for no obvious reason). This was happening because some options do not have a buffer local value. In these cases, setlocal will simply modify the global instead (see `:help setl`). Details of removed settings and why I removed them are here.

* `showcmd`, `noruler`, `noshowmode` and `laststatus` have no local values, so global configuration was being modified. It seems like a bug that the plugin enforces a specific global configuration that has no impact on plugin functionality.
* `hidden` is essentially just the default value for `bufhidden`. It has no local value and setting the global value is unnecessary since the buffer local `bufhidden=hide` is used for this buffer anyway

I also screwed up my git-fu and accidently left a commit from https://github.com/thosakwe/vim-flutter/pull/11 in here too.