### PR TITLE
job_start windows fix and job_status verification

### DIFF
--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -111,9 +111,9 @@ function! flutter#run(...) abort
     setlocal noswapfile
   endif
 
-  let cmd = g:flutter_command.' run'
+  let cmd = [&shell, &shellcmdflag, g:flutter_command, 'run']
   if !empty(a:000)
-    let cmd .= ' '.join(a:000)
+    let cmd += a:000
   endif
 
   if has('nvim')
@@ -128,8 +128,13 @@ function! flutter#run(...) abort
           \ 'out_name': '__Flutter_Output__',
           \ 'err_io': 'buffer',
           \ 'err_name': '__Flutter_Output__',
-          \ 'exit_cb': 'flutter#_exit_cb',
+          \ 'exit_cb': function('flutter#_exit_cb')
           \ })
+
+      if job_status(g:flutter_job) == 'fail'
+        echo 'Starting job failed'
+        unlet g:flutter_job
+      endif
   else
     echoerr 'This vim does not support async jobs needed for running Flutter.'
   endif


### PR DESCRIPTION
`FlutterRun` command wasn't working on Vim on Windows.

Vim version:
```
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Dec  3 2017 23:02:00)
MS-Windows 64-bit GUI version with OLE support
```

This pull request contains fix which should be universal for all operating systems.  But I have no way to test it on the mac and linux now.

The fix is based on code comparison with [asyncrun](https://github.com/skywind3000/asyncrun.vim) plugin so I'm quite convinced that it will work on all systems now.

Additionally I added check to confirm if `job_start` succeeded.

