### PR TITLE
add config to reuse the last option of FlutterRun

### DIFF
--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -113,7 +113,14 @@ function! flutter#run(...) abort
 
   let cmd = g:flutter_command.' run'
   if !empty(a:000)
-    let cmd .= ' '.join(a:000)
+    let cmd += a:000
+    if g:flutter_use_last_run_option
+      let g:flutter_last_run_option = a:000
+    endif
+  else
+    if g:flutter_use_last_run_option && exists('g:flutter_last_run_option')
+      let cmd += g:flutter_last_run_option
+    endif
   endif
 
   if has('nvim')

--- a/doc/flutter.txt
+++ b/doc/flutter.txt
@@ -35,7 +35,7 @@ g:flutter_use_last_run_option     *g:flutter_use_last_run_option*
 Reuse the command option of the last `FlutterRun`.
 Once `FlutterRun` executed w/ some option, following `FlutterRun`
 will execute w/ the last option.
-Overwirte saved option string when option specified execution.
+Overwrite
 defaults to `0`.
 
 :FlutterRun                                         *:FlutterRun*

--- a/doc/flutter.txt
+++ b/doc/flutter.txt
@@ -30,6 +30,14 @@ Setting this to `0` requires `set hidden` in your vimrc.
 
 See |buffer-hidden|.
 
+g:flutter_use_last_run_option     *g:flutter_use_last_run_option*
+
+Reuse the command option of the last `FlutterRun`.
+Once `FlutterRun` executed w/ some option, following `FlutterRun`
+will execute w/ the last option.
+Overwirte saved option string when option specified execution.
+defaults to `0`.
+
 :FlutterRun                                         *:FlutterRun*
 
 Starts a Flutter process in the current directory, if

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -16,6 +16,10 @@ if !exists('g:flutter_hot_restart_on_save')
   let g:flutter_hot_restart_on_save=0
 endif
 
+if !exists('g:flutter_use_last_run_option')
+  let g:flutter_use_last_run_option=0
+endif
+
 if !exists('g:flutter_show_log_on_run')
   let g:flutter_show_log_on_run=1
 elseif &hidden == 0 && g:flutter_show_log_on_run == 0


### PR DESCRIPTION
when multiple devices connected, `FlutterRun` should run w/ option `-d`.
this option will help for debugging that repeats `FlutterRun` and `FlutterQuit` many times.