### PR TITLE
Fix error when FlutterRun is called with some arguments

### DIFF
--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -113,7 +113,7 @@ function! flutter#run(...) abort
 
   let cmd = g:flutter_command.' run'
   if !empty(a:000)
-    let cmd += a:000
+    let cmd = cmd." ".join(a:000)
     if g:flutter_use_last_run_option
       let g:flutter_last_run_option = a:000
     endif


### PR DESCRIPTION
The previous concatenation method causes an error when :FlutterRun is run with some arguments Ej: Flutter Run -d chrome