### PR TITLE
Support initial height for the split of FlutterSplit,-Run,-Attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ flutter using `:FlutterRun`; it can have one of the following values:
   * `"hidden"` or `0`: Do not open the log by default, can be opened later with `FlutterSplit` etc.
 * `g:flutter_show_log_on_attach` - Identical to `g:flutter_show_log_on_run` but affecting
 the `:FlutterAttach` command.
+* `g:flutter_split_height` - Initial height of the window opened by `:FlutterSplit` (or `:FlutterRun` and
+  `:FlutterAttach`, when `g:flutter_show_log_on_run` is set to `"split"`); defaults to standard vim behavior,
+  which is splitting the window in half.
 * `g:flutter_autoscroll` - Autoscroll the flutter log when `1`, defaults to `0`.
 * `g:flutter_use_last_run_option` - When set to `1` then `:FlutterRun` will use the arguments from
 the previous call when no arguments are specified.

--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -127,7 +127,7 @@ function! flutter#run_or_attach(type, show, use_last_option, args) abort
     tabnew __Flutter_Output__
     tabm -1
   else
-    split __Flutter_Output__
+    execute g:flutter_split_height."split" "__Flutter_Output__"
   endif
   normal! ggdG
   setlocal buftype=nofile

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -8,6 +8,10 @@ if !exists('g:flutter_command')
   let g:flutter_command='flutter'
 endif
 
+if !exists('g:flutter_split_height')
+    let g:flutter_split_height=''
+endif
+
 if !exists('g:flutter_autoscroll')
   let g:flutter_autoscroll=0
 endif

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -63,7 +63,7 @@ if g:flutter_hot_restart_on_save
   autocmd! BufWritePost *.dart call flutter#hot_restart_quiet()
 endif
 
-command! FlutterSplit :split __Flutter_Output__ | call flutter#scroll_to_bottom()
+command! FlutterSplit :execute g:flutter_split_height."split" "__Flutter_Output__" | call flutter#scroll_to_bottom()
 command! FlutterVSplit :vsplit __Flutter_Output__ | call flutter#scroll_to_bottom()
 command! FlutterTab :tabnew __Flutter_Output__ | call flutter#scroll_to_bottom()
 


### PR DESCRIPTION
Add a variable controlling the initial height of the window created by `:FlutterSplit` (or `:FlutterRun` and `:FlutterAttach`, if `g:flutter_show_log_on_run` is set to `"split"`).