### PR TITLE
Check for flutter window before opening new one

### DIFF
--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -122,19 +122,22 @@ function! flutter#run_or_attach(type, show, use_last_option, args) abort
     return 0
   endif
 
-  if a:show == 'tab' || a:show == 'hidden'
-    " open new tab and move it before the current tab
-    tabnew __Flutter_Output__
-    tabm -1
-  else
-    execute g:flutter_split_height."split" "__Flutter_Output__"
-  endif
-  normal! ggdG
-  setlocal buftype=nofile
-  setlocal bufhidden=hide
-  setlocal noswapfile
-  if a:show == 'hidden'
-    tabclose
+  let l:bufinfo = getbufinfo('__Flutter_Output__')
+  if len(l:bufinfo) == 0 || len(l:bufinfo[0].windows) == 0
+    if a:show == 'tab' || a:show == 'hidden'
+      " open new tab and move it before the current tab
+      tabnew __Flutter_Output__
+      tabm -1
+    else
+      execute g:flutter_split_height."split" "__Flutter_Output__"
+    endif
+    normal! ggdG
+    setlocal buftype=nofile
+    setlocal bufhidden=hide
+    setlocal noswapfile
+    if a:show == 'hidden'
+      tabclose
+    endif
   endif
 
   let cmd = []


### PR DESCRIPTION
Before opening a new window for the __Flutter_Output__ buffer in flutter#run_or_attach(), check for a window already being open for that buffer to avoid duplicate flutter windows when calling FlutterRun a second time after having run FlutterQuit in-between.