### PR TITLE
Optionally close all __Flutter_Output__ windows on FlutterQuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ the `:FlutterAttach` command.
 the previous call when no arguments are specified.
 * `g:flutter_use_last_attach_option` - Identical to `g:flutter_use_last_run_option` but
 affecting the `:FlutterAttach` command.
+* `g:flutter_close_on_quit` - Whether to close all `__Flutter_Output__` windows (splits and tabs) on `:FlutterQuit`;
+defaults to `0`.
 
 ## Provided Commands
 * `:FlutterRun <args>` - calls `flutter run <args>`

--- a/autoload/flutter.vim
+++ b/autoload/flutter.vim
@@ -61,7 +61,16 @@ function! flutter#hot_restart_quiet() abort
 endfunction
 
 function! flutter#quit() abort
-  return flutter#send('q')
+  let l:ret = flutter#send('q')
+  if g:flutter_close_on_quit
+    let l:bufinfo = getbufinfo('__Flutter_Output__')
+    if len(l:bufinfo) > 0
+      for l:win_id in l:bufinfo[0].windows
+        call win_execute(l:win_id, 'close')
+      endfor
+    endif
+  endif
+  return l:ret
 endfunction
 
 function! flutter#screenshot() abort

--- a/doc/flutter.txt
+++ b/doc/flutter.txt
@@ -1,4 +1,4 @@
-*flutter.txt*	For Vim version 8.1	Last change: 2018 March 13
+*flutter.txt*	For Vim version 8.1	Last change: 2023 June 5
 
                          Flutter ~
 
@@ -37,6 +37,11 @@ Once `FlutterRun` executed w/ some option, following `FlutterRun`
 will execute w/ the last option.
 Overwrite
 defaults to `0`.
+
+g:flutter_close_on_quit                 *g:flutter_close_on_quit*
+Whether to automatically close all `__Flutter_Output__` windows
+(splits and tabs) when calling |:FlutterQuit|.
+Defaults to `0`.
 
 :FlutterRun                                         *:FlutterRun*
 

--- a/plugin/flutter.vim
+++ b/plugin/flutter.vim
@@ -44,6 +44,10 @@ elseif type(g:flutter_show_log_on_attach) == v:t_number && g:flutter_show_log_on
   let g:flutter_show_log_on_attach="hidden"
 endif
 
+if !exists('g:flutter_close_on_quit')
+    let g:flutter_close_on_quit=0
+endif
+
 command! FlutterDevices call flutter#devices()
 command! FlutterEmulators call flutter#emulators()
 command! -nargs=1 FlutterEmulatorsLaunch call flutter#emulators_launch(<f-args>)


### PR DESCRIPTION
Add a variable `g:flutter_close_on_quit`, defaulting to `0`, which enables automatically closing all `__Flutter_Output__` windows (splits and tabs) when running `:FlutterQuit`.